### PR TITLE
fix: Update deprecated method usage.

### DIFF
--- a/calib_eq_odds.py
+++ b/calib_eq_odds.py
@@ -201,10 +201,10 @@ if __name__ == '__main__':
     group_0_test_data = test_data[test_data['group'] == 0]
     group_1_test_data = test_data[test_data['group'] == 1]
 
-    group_0_val_model = Model(group_0_val_data['prediction'].as_matrix(), group_0_val_data['label'].as_matrix())
-    group_1_val_model = Model(group_1_val_data['prediction'].as_matrix(), group_1_val_data['label'].as_matrix())
-    group_0_test_model = Model(group_0_test_data['prediction'].as_matrix(), group_0_test_data['label'].as_matrix())
-    group_1_test_model = Model(group_1_test_data['prediction'].as_matrix(), group_1_test_data['label'].as_matrix())
+    group_0_val_model = Model(group_0_val_data['prediction'].values, group_0_val_data['label'].values)
+    group_1_val_model = Model(group_1_val_data['prediction'].values, group_1_val_data['label'].values)
+    group_0_test_model = Model(group_0_test_data['prediction'].values, group_0_test_data['label'].values)
+    group_1_test_model = Model(group_1_test_data['prediction'].values, group_1_test_data['label'].values)
 
     # Find mixing rates for equalized odds models
     _, _, mix_rates = Model.calib_eq_odds(group_0_val_model, group_1_val_model, fp_rate, fn_rate)

--- a/eq_odds.py
+++ b/eq_odds.py
@@ -228,10 +228,10 @@ if __name__ == '__main__':
     group_0_test_data = test_data[test_data['group'] == 0]
     group_1_test_data = test_data[test_data['group'] == 1]
 
-    group_0_val_model = Model(group_0_val_data['prediction'].as_matrix(), group_0_val_data['label'].as_matrix())
-    group_1_val_model = Model(group_1_val_data['prediction'].as_matrix(), group_1_val_data['label'].as_matrix())
-    group_0_test_model = Model(group_0_test_data['prediction'].as_matrix(), group_0_test_data['label'].as_matrix())
-    group_1_test_model = Model(group_1_test_data['prediction'].as_matrix(), group_1_test_data['label'].as_matrix())
+    group_0_val_model = Model(group_0_val_data['prediction'].values, group_0_val_data['label'].values)
+    group_1_val_model = Model(group_1_val_data['prediction'].values, group_1_val_data['label'].values)
+    group_0_test_model = Model(group_0_test_data['prediction'].values, group_0_test_data['label'].values)
+    group_1_test_model = Model(group_1_test_data['prediction'].values, group_1_test_data['label'].values)
 
     # Find mixing rates for equalized odds models
     _, _, mix_rates = Model.eq_odds(group_0_val_model, group_1_val_model)


### PR DESCRIPTION
This commit updates the usage of a deprecated method `.as_matrix()`
to a suitable alternative `.values()` in order to ensure compatibility
with modern pandas versions and prevent potential issues arising from
deprecated functionalities.